### PR TITLE
Adjust the docs for server run success

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -143,7 +143,7 @@ Using paste's built-in webserver
 
 Simply execute::
 
-    paster serve debexpo.ini
+    paster serve development.ini
 
 and visit http://localhost:5000/ in your web browser.
 


### PR DESCRIPTION
- debexpo.ini doesn't seem to actually exist?
- development.ini works just fine for development
