### PR TITLE
Use HTTPS URL for git status image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,5 +53,5 @@ Git synchronization
 
 This repository is synchronized to Alioth, the official home of the project.
 
-.. image:: http://rose.makesad.us/~debexpogitmirror/git-status.png
+.. image:: https://secure.makesad.us/~debexpogitmirror/git-status.png
     :target: https://github.com/debexpo/alioth-sync-scripts


### PR DESCRIPTION
With HTTP, the image gets converted into a https image by github's mixed content avoiding tool.

This results in the image being cached for a long time. So now we use a HTTPS URL to real image.
