### PR TITLE
In development, do not use mentors.debian.net in email or as sitename

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -54,16 +54,16 @@ debexpo.handle_debian = true
 debexpo.sitetitle = Mentors
 
 # Site name
-debexpo.sitename = mentors.debian.net
+debexpo.sitename = debexpo-dev-code
 
 # Site tagline
-debexpo.tagline = Helps you get your packages into Debian
+debexpo.tagline = Development site for debexpo, the code behind mentors.debian.net
 
 # Site logo
 debexpo.logo = /debexpo-logo.png
 
 # Site support email
-debexpo.email = support@mentors.debian.net
+debexpo.email = support@debexpo-staging.debian.net
 
 # Whether to show Debian-specific options
 debexpo.debian_specific = true


### PR DESCRIPTION
This way, the staging site won't cause the nice support at mentors.debian.net people to get confusing email.
