### PR TITLE
Add toctree directives to docs/index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,25 +16,34 @@ like PostgreSQL, MySQL or Sqlite.
 Setting up debexpo
 ------------------
 
-* :ref:`installing`
-* :ref:`config-file`
+.. toctree::
+    :maxdepth: 1
+
+    installing
+    config_file
 
 Using debexpo
 -------------
 
-* :ref:`uploading`
-* :ref:`plugins`
-* :ref:`soap`
+.. toctree::
+    :maxdepth: 1
+
+    uploading
+    plugins
+    soap
 
 Development documentation
 -------------------------
 
-* :ref:`building`
-* :ref:`writing-plugins`
-* :ref:`writing-cronjobs`
-* :ref:`coding-standards`
-* :ref:`contributing`
-* :ref:`api`
+.. toctree::
+    :maxdepth: 1
+
+    building
+    writing_plugins
+    writing_cronjobs
+    coding_standards
+    contributing
+    api
 
 Indices and tables
 ==================

--- a/docs/writing_cronjobs.rst
+++ b/docs/writing_cronjobs.rst
@@ -54,13 +54,13 @@ if you need any setup. The following attributes will be instantiated for your
 cronjob:
 
 ``self.parent``
---------------
+---------------
 
 This is a reference to the worker object, which instantiated your cronjob. You can
 call any method in from there, if necessary.
 
 ``self.config``
---------------
+---------------
 
 This is an instantiated configuration object. You can access every Debexpo
 configuration setting from it.


### PR DESCRIPTION
This PR adds toctree directives to docs/index.rst to fix Sphinx build warnings and also fixes some "heading underline too short" warnings. :-)

Let me know what you think!

Thanks!
Eeshan
