### PR TITLE
templates/intro-maintainers: fix typo s/fist/first/

### DIFF
--- a/debexpo/templates/index/intro-maintainers.mako
+++ b/debexpo/templates/index/intro-maintainers.mako
@@ -124,7 +124,7 @@ If you did everything right, you will get a confirmation mail from our site and 
 
 <h2>7. Maintaining your package in Debian</h2>
 
-<p>Please see the corresponding chapter in the <a href="http://www.debian.org/doc/manuals/maint-guide/update">New Maintainer's Guide</a> to get the idea. Whenever you feel like, you should update your package in Debian. The general procedure is not different from your fist upload. Please upload your updated package to ${ config['debexpo.sitename'] } and notify your former sponsor about your change. Alternatively, follow ${ h.tags.link_to("the usual procedures", h.url(controller='sponsor', action='index')) }.</p>
+<p>Please see the corresponding chapter in the <a href="http://www.debian.org/doc/manuals/maint-guide/update">New Maintainer's Guide</a> to get the idea. Whenever you feel like, you should update your package in Debian. The general procedure is not different from your first upload. Please upload your updated package to ${ config['debexpo.sitename'] } and notify your former sponsor about your change. Alternatively, follow ${ h.tags.link_to("the usual procedures", h.url(controller='sponsor', action='index')) }.</p>
 
 <p>If your package passes through the sponsoring process for <em>a few</em> successive uploads without any notable correction by your sponsor, you can become a <a href="http://wiki.debian.org/DebianMaintainer">Debian Maintainer</a> which grants you limited upload rights to Debian directly. Get in touch with your sponsor to discuss your chances here. You can also <a href="http://www.debian.org/devel/join/">become a Debian Developer</a> giving you full membership in the project.</p>
 


### PR DESCRIPTION
just a typo reported on #debian-mentors
