### PR TITLE
Support mailto for RFS template

### DIFF
--- a/debexpo/controllers/sponsor.py
+++ b/debexpo/controllers/sponsor.py
@@ -39,6 +39,7 @@ import logging
 import random
 import struct
 import socket
+import json
 
 from debexpo.lib.base import BaseController, c, config, render, session, \
     redirect, url, abort, request, SubMenu, _
@@ -206,11 +207,19 @@ class SponsorController(BaseController):
 
         c.package = None
         c.package_dir = None
+        c.rfstemplate = None
         if packagename:
             package = meta.session.query(Package).filter_by(name=packagename).first()
             if package:
                 c.package = package
                 c.package_dir = get_package_dir(package.name)
+
+                latest = meta.session.query(PackageVersion).filter_by(package_id=package.id).order_by(PackageVersion.id.desc()).first()
+                if latest:
+                    rfstemplate = meta.session.query(PackageInfo).filter_by(package_version_id=latest.id).filter_by(from_plugin='rfstemplate').first()
+                    if rfstemplate:
+                        c.rfstemplate = json.loads(rfstemplate.data)
+                c.mailbody = render('/sponsor/rfs_template.mako')
 
         return render('/sponsor/rfs_howto.mako')
 

--- a/debexpo/controllers/sponsor.py
+++ b/debexpo/controllers/sponsor.py
@@ -241,6 +241,14 @@ class SponsorController(BaseController):
                 else:
                     c.category = '[' + ', '.join(category) + ']'
 
+                if qadata:
+                    if not qadata['in-debian']:
+                        c.severity = 'wishlist'
+                    else:
+                        c.severity = 'normal [important for RC bugs]'
+                else:
+                    c.severity = 'normal [important for RC bugs, wishlist for new packages]'
+
                 c.mailbody = render('/sponsor/rfs_template.mako')
 
         return render('/sponsor/rfs_howto.mako')

--- a/debexpo/controllers/sponsor.py
+++ b/debexpo/controllers/sponsor.py
@@ -219,6 +219,28 @@ class SponsorController(BaseController):
                     rfstemplate = meta.session.query(PackageInfo).filter_by(package_version_id=latest.id).filter_by(from_plugin='rfstemplate').first()
                     if rfstemplate:
                         c.rfstemplate = json.loads(rfstemplate.data)
+
+                category = []
+                debianqa = meta.session.query(PackageInfo).filter_by(package_version_id=latest.id).filter_by(from_plugin='debianqa').first()
+                if debianqa:
+                    qadata = json.loads(debianqa.data)
+                    if 'nmu' in qadata and qadata['nmu']:
+                        category.append('NMU')
+                    elif 'qa' in qadata and qadata['qa']:
+                        category.append('QA')
+                    elif 'in-debian' in qadata and not qadata['in-debian']:
+                        category.append('ITP')
+                    elif 'in-debian' in qadata and qadata['in-debian']:
+                        # TODO: RC or regular update
+                        pass
+                    else:
+                        # TODO: ITA
+                        pass
+                if len(category) == 0:
+                    c.category = "[put in ITP, ITA, RC, NMU if applicable]"
+                else:
+                    c.category = '[' + ', '.join(category) + ']'
+
                 c.mailbody = render('/sponsor/rfs_template.mako')
 
         return render('/sponsor/rfs_howto.mako')

--- a/debexpo/plugins/rfstemplate.py
+++ b/debexpo/plugins/rfstemplate.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+#
+#   rfstemplate.py - collect information for RFS template plugin
+#
+#   Copyright © 2016 Hayashi Kentaro <kenhys@gmail.com>
+#
+#   Permission is hereby granted, free of charge, to any person
+#   obtaining a copy of this software and associated documentation
+#   files (the "Software"), to deal in the Software without
+#   restriction, including without limitation the rights to use,
+#   copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following
+#   conditions:
+#
+#   The above copyright notice and this permission notice shall be
+#   included in all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#   OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#   OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Holds the RFS template plugin.
+"""
+
+__author__ = 'Hayashi Kentaro'
+__copyright__ = 'Copyright © 2016 Hayashi Kentaro'
+__license__ = 'MIT'
+
+import logging
+import os
+
+from debian import deb822, copyright
+from debexpo.lib import constants
+from debexpo.plugins import BasePlugin
+
+from debexpo.model import meta
+from debexpo.model.users import User
+
+log = logging.getLogger(__name__)
+
+class RfsTemplatePlugin(BasePlugin):
+
+    def _extract_copyright_info(self):
+        dict = {}
+        copyright_path = os.path.join(self.tempdir, "extracted/debian/copyright")
+        with open(copyright_path, 'r') as f:
+            context = copyright.Copyright(f)
+            header = context.header
+            if header.upstream_contact:
+                dict['author'] = header.upstream_contact[0]
+
+            lic = header.license
+            if lic:
+                dict['license'] = lic.synopsis
+
+            if not lic:
+                default_license = context.find_files_paragraph('*')
+                if default_license:
+                    dict['license'] = default_license.license.synopsis
+        return dict
+
+    def _extract_control_info(self):
+        dict = {}
+        control_path = os.path.join(self.tempdir, "extracted/debian/control")
+        with open(control_path, 'r') as f:
+            content = deb822.Deb822(f)
+            if 'Homepage' in content:
+                dict['url'] = content['Homepage']
+        return dict
+
+    def test_rfs_template(self):
+        """
+        Tests whether there are enough information for RFS template.
+
+        This plugin collects:
+        
+        - Upstream Author (from debian/copyright)
+        - URL (from debian/control)
+        - License (from debian/copyright)
+        - Changelog (from debian/changelog)
+        
+        """
+        log.debug('Checking whether there are enough information for RFS template')
+        upstream_author = "[fill in name and email of upstream]"
+        upstream_license = "[fill in]"
+        upstream_url = "[fill in URL of upstream's web site]"
+        package_changelog = "[your most recent changelog entry]"
+        
+        if self.user_id is not None:
+
+            user = meta.session.query(User).get(self.user_id)
+            log.debug(user)
+            
+            package_changelog = self.changes['Changes']
+
+            copyright_info = self._extract_copyright_info()
+            control_info = self._extract_control_info()
+
+            if 'author' in copyright_info:
+                upstream_author = copyright_info['author']
+            if 'license' in copyright_info:
+                upstream_license = copyright_info['license']
+
+            if 'url' in control_info:
+                upstream_url = control_info['url']
+                
+            print('  Upstream Author : %s' % upstream_author)
+            print('* URL             : %s' % upstream_url)
+            print('* License         : %s' % upstream_license)
+            print('  Changes         : %s' % package_changelog)
+
+            data = {
+                'upstream-author': upstream_author,
+                'upstream-url': upstream_url,
+                'upstream-license': upstream_license,
+                'package-changelog': package_changelog,
+            }
+
+            outcome = "RFS template information"
+            severity = constants.PLUGIN_SEVERITY_INFO
+            self.passed(outcome, data, severity)
+        else:
+            log.warning('Could not get the uploader\'s user details from the database')
+
+plugin = RfsTemplatePlugin

--- a/debexpo/templates/sponsor/rfs_howto.mako
+++ b/debexpo/templates/sponsor/rfs_howto.mako
@@ -78,9 +78,15 @@ tool.
  * Package name    : hello
    Version         : 3.1-4
 %endif
+%if c.rfstemplate:
+   Upstream Author : ${ c.rfstemplate['upstream-author'] }
+ * URL             : ${ c.rfstemplate['upstream-url'] }
+ * License         : ${ c.rfstemplate['upstream-license'] }
+%else:
    Upstream Author : [fill in name and email of upstream]
  * URL             : [fill in URL of upstream's web site]
  * License         : [fill in]
+%endif
 %if c.package:
    Section         : ${ c.package.package_versions[-1].section }
 %else:
@@ -116,12 +122,23 @@ tool.
   dget -x ${ c.config['debexpo.server'] }/debian/pool/main/h/hello/hello_3.1-4.dsc
 %endif
 
+%if c.package:
+  %if c.rfstemplate:
+  More information about ${ c.package.name } can be obtained from ${ c.rfstemplate['upstream-url'] }.
+  %else:
+  More information about ${ c.package.name } can be obtained from http://www.example.com.
+  %endif
+%else:
   More information about hello can be obtained from http://www.example.com.
+%endif
 
   Changes since the last upload:
 
+%if c.rfstemplate:
+  ${ c.rfstemplate['package-changelog'] }
+%else:
   [your most recent changelog entry]
-
+%endif
 
   Regards,
 %if c.package:

--- a/debexpo/templates/sponsor/rfs_howto.mako
+++ b/debexpo/templates/sponsor/rfs_howto.mako
@@ -38,7 +38,7 @@ list. You can browser other packages and give other people feedback while you ar
 </h2>
 
 <p>
-Send the filled out template below by mail to our pseudo-package. If you
+<a href="mailto:submit@bugs.debian.org?subject=RFS: ${ c.package.name }/${ c.package.package_versions[-1].version } [put in ITP, ITA, RC, NMU if applicable]&body=${ c.mailbody | u }">Send the filled out template below by mail</a> to our pseudo-package. If you
 prefer, you can also use the <a
 href="http://packages.debian.org/search?keywords=reportbug&searchon=names&exact=1&suite=all&section=main">reportbug</a>
 tool.

--- a/debexpo/templates/sponsor/rfs_howto.mako
+++ b/debexpo/templates/sponsor/rfs_howto.mako
@@ -61,7 +61,7 @@ tool.
 
 
   Package: sponsorship-requests
-  Severity: normal [important for RC bugs, wishlist for new packages]
+  Severity: ${ c.severity }
 
   Dear mentors,
 

--- a/debexpo/templates/sponsor/rfs_howto.mako
+++ b/debexpo/templates/sponsor/rfs_howto.mako
@@ -38,7 +38,7 @@ list. You can browser other packages and give other people feedback while you ar
 </h2>
 
 <p>
-<a href="mailto:submit@bugs.debian.org?subject=RFS: ${ c.package.name }/${ c.package.package_versions[-1].version } [put in ITP, ITA, RC, NMU if applicable]&body=${ c.mailbody | u }">Send the filled out template below by mail</a> to our pseudo-package. If you
+<a href="mailto:submit@bugs.debian.org?subject=RFS: ${ c.package.name }/${ c.package.package_versions[-1].version } ${ c.category }&body=${ c.mailbody | u }">Send the filled out template below by mail</a> to our pseudo-package. If you
 prefer, you can also use the <a
 href="http://packages.debian.org/search?keywords=reportbug&searchon=names&exact=1&suite=all&section=main">reportbug</a>
 tool.
@@ -53,7 +53,7 @@ tool.
 %endif
   To: submit@bugs.debian.org
 %if c.package:
-  Subject: RFS: ${ c.package.name }/${ c.package.package_versions[-1].version } [put in ITP, ITA, RC, NMU if applicable]
+  Subject: RFS: ${ c.package.name }/${ c.package.package_versions[-1].version } ${ c.category }
 %else:
   Subject: RFS: hello/3.1-4 [put in ITP, ITA, RC, NMU if applicable] -- friendly greeter
 %endif

--- a/debexpo/templates/sponsor/rfs_template.mako
+++ b/debexpo/templates/sponsor/rfs_template.mako
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+Package: sponsorship-requests
+Severity: normal [important for RC bugs, wishlist for new packages]
+
+Dear mentors,
+
+%if c.package:
+I am looking for a sponsor for my package "${ c.package.name }"
+%else:
+I am looking for a sponsor for my package "hello":
+%endif
+
+%if c.package:
+* Package name    : ${ c.package.name }
+  Version         : ${ c.package.package_versions[-1].version }
+%else:
+* Package name    : hello
+  Version         : 3.1-4
+%endif
+%if c.rfstemplate:
+  Upstream Author : ${ c.rfstemplate['upstream-author'] }
+* URL             : ${ c.rfstemplate['upstream-url'] }
+* License         : ${ c.rfstemplate['upstream-license'] }
+%else:
+  Upstream Author : [fill in name and email of upstream]
+* URL             : [fill in URL of upstreams web site]
+* License         : [fill in]
+%endif
+%if c.package:
+  Section         : ${ c.package.package_versions[-1].section }
+%else:
+  Section         : [fill in]
+%endif
+
+It builds those binary packages:
+
+%if c.package:
+  ${ c.package.description }
+%else:
+  hello - friendly greeter
+%endif
+
+To access further information about this package, please visit the following URL:
+
+%if c.package:
+${ c.config['debexpo.server'] }${ h.url('package', packagename=c.package.name) }
+%else:
+${ c.config['debexpo.server'] }/package/hello
+%endif
+
+Alternatively, one can download the package with dget using this command:
+
+%if c.package:
+% for pkgfile in c.package.package_versions[-1].source_packages[0].package_files:
+  % if pkgfile.filename.endswith('.dsc'):
+  dget -x ${ c.config['debexpo.server'] }/debian/${ pkgfile.filename }
+  % endif
+% endfor
+%else:
+  dget -x ${ c.config['debexpo.server'] }/debian/pool/main/h/hello/hello_3.1-4.dsc
+%endif
+
+%if c.package:
+%if c.rfstemplate:
+More information about ${ c.package.name } can be obtained from ${ c.rfstemplate['upstream-url'] }.
+%else:
+More information about ${ c.package.name } can be obtained from http://www.example.com.
+%endif
+%else:
+More information about hello can be obtained from http://www.example.com.
+%endif
+
+Changes since the last upload:
+
+%if c.rfstemplate:
+${ c.rfstemplate['package-changelog'] }
+%else:
+[your most recent changelog entry]
+%endif
+
+Regards,
+%if c.package:
+ ${ c.package.user.name }
+%else:
+  J. Maintainer
+%endif

--- a/debexpo/templates/sponsor/rfs_template.mako
+++ b/debexpo/templates/sponsor/rfs_template.mako
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 Package: sponsorship-requests
-Severity: normal [important for RC bugs, wishlist for new packages]
+Severity: ${ c.severity }
 
 Dear mentors,
 

--- a/development.ini
+++ b/development.ini
@@ -72,7 +72,7 @@ debexpo.debian_specific = true
 debexpo.plugins.post_upload = getorigtarball notuploader
 
 # What qa plugins to run, in this order
-debexpo.plugins.qa = lintian native maintaineremail watchfile closedbugs controlfields diffclean buildsystem debianqa distribution
+debexpo.plugins.qa = lintian native maintaineremail watchfile closedbugs controlfields rfstemplate diffclean buildsystem debianqa distribution
 
 # What plugins to run when the package is uploaded to Debian, in this order
 debexpo.plugins.post_upload_to_debian = removepackage


### PR DESCRIPTION
This PR aims to provide the following features
- Support mailto: link to send RFS via E-mail
- Show more package detail in /sponsor/rfs-howto/[PACKAGE] page
  such as upstream author, url, license and changelog
