### PR TITLE
Fix broken test on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ install:
   - sudo apt-get update
 # Now, set up postfix to discard all outbound email,
   - sudo apt-get install postfix
-  - echo '* discard:' | sudo sh -c 'cat > /etc/postfix/discard-transport'
-  - echo 'transport_maps = hash:/etc/postfix/discard-transport' | sudo sh -c 'cat >> /etc/postfix/main.cf'
+  - echo '* discard:' | sudo tee /etc/postfix/discard-transport
+  - echo 'transport_maps = hash:/etc/postfix/discard-transport' | sudo tee -a /etc/postfix/main.cf
   - sudo postmap /etc/postfix/discard-transport
   - sudo service postfix restart
 # OK, install normal dependencies.

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - sudo apt-get install postfix
   - echo '* discard:' | sudo tee /etc/postfix/discard-transport
   - echo 'transport_maps = hash:/etc/postfix/discard-transport' | sudo tee -a /etc/postfix/main.cf
+  - echo '2525       inet  n       -       -       -       -       smtpd' | sudo tee -a /etc/postfix/master.cf
   - sudo postmap /etc/postfix/discard-transport
   - sudo service postfix restart
 # OK, install normal dependencies.

--- a/debexpo/lib/email.py
+++ b/debexpo/lib/email.py
@@ -80,6 +80,10 @@ class Email(object):
         """
         self.template = template
         self.server = pylons.config['global_conf']['smtp_server']
+        if 'smtp_port' in pylons.config['global_conf']:
+            self.port = pylons.config['global_conf']['smtp_port']
+        else:
+            self.port = smtplib.SMTP_PORT
         self.auth = None
 
         # Look whether auth is required.
@@ -146,8 +150,8 @@ class Email(object):
 
         pylons.url._pop_object()
 
-        log.debug('Starting SMTP session to %s' % self.server)
-        session = smtplib.SMTP(self.server)
+        log.debug('Starting SMTP session to %s:%s' % (self.server, self.port))
+        session = smtplib.SMTP(self.server, self.port)
 
         if self.auth:
             log.debug('Authentication requested; logging in')

--- a/test.ini
+++ b/test.ini
@@ -10,6 +10,7 @@ debug = true
 smtp_server = localhost
 smtp_username =
 smtp_password =
+smtp_port = 2525
 error_email_from = paste@localhost
 
 [server:main]


### PR DESCRIPTION
.travis.yml configuration is broken for recent Travis-CI environment.

It seems that the problem is derived from using default SMTP port 25,
so using alternative port such as 2525 (for example) fixes the above issue.
