### PR TITLE
Accept --skip-gpg-check by debexpo_importer.py

### DIFF
--- a/debexpo/importer/importer.py
+++ b/debexpo/importer/importer.py
@@ -470,7 +470,8 @@ class Importer(object):
 
         log.debug('Importer started with arguments: %s' % sys.argv[1:])
         filecheck = CheckFiles()
-        gpg = get_gnupg()
+        if not self.skip_gpg:
+            gpg = get_gnupg()
 
         # Try parsing the changes file, but fail if there's an error.
         try:


### PR DESCRIPTION
Without this change, importer try to execute gpg check even though --skip-gpg-check is specified.

  Traceback (most recent call last):
    File "./bin/debexpo_importer.py", line 60, in <module>
      i.main()
    File "/home/vagrant/debexpo/debexpo/importer/importer.py", line 473, in main
      gpg = get_gnupg()
    File "/home/vagrant/debexpo/debexpo/lib/utils.py", line 119, in get_gnupg
      return gnupg.GnuPG(config['debexpo.gpg_path'],
    File "/home/vagrant/debexpo/venv/local/lib/python2.7/site-packages/paste/registry.py", line 146, in **getitem**
      return self._current_obj()[key]
  KeyError: 'debexpo.gpg_path'
