### PR TITLE
Migrate development environment to jessie

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "bento/debian-7.10"
+  config.vm.define :jessie do |vagrant|
+    vagrant.vm.box = "bento/debian-8.4"
+  end
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.

--- a/provision.sh
+++ b/provision.sh
@@ -5,21 +5,19 @@ set -e
 # For some reasons the tests want this.
 mkdir -p ~/.gnupg
 
+DEBIAN_RELEASE=$(lsb_release -c | awk '{print $2}')
+
 cd ~/debexpo/
-if ! grep -q backports /etc/apt/sources.list; then
-    echo 'deb http://http.debian.net/debian/ wheezy-backports main contrib non-free' | sudo sh -c 'cat >> /etc/apt/sources.list'
-fi
 if ! grep -q deb-src /etc/apt/sources.list; then
-    echo 'deb-src http://mirrors.kernel.org/debian wheezy main' | sudo sh -c 'cat >> /etc/apt/sources.list'
-    echo 'deb-src http://security.debian.org/ wheezy/updates main' | sudo sh -c 'cat >> /etc/apt/sources.list'
-    echo 'deb-src http://mirrors.kernel.org/debian wheezy-updates main' | sudo sh -c 'cat >> /etc/apt/sources.list'
+    echo "deb-src http://mirrors.kernel.org/debian ${DEBIAN_RELEASE} main" | sudo sh -c 'cat >> /etc/apt/sources.list'
+    echo "deb-src http://security.debian.org/ ${DEBIAN_RELEASE}/updates main" | sudo sh -c 'cat >> /etc/apt/sources.list'
+    echo "deb-src http://mirrors.kernel.org/debian ${DEBIAN_RELEASE}-updates main" | sudo sh -c 'cat >> /etc/apt/sources.list'
 fi
 export DEBIAN_FRONTEND=noninteractive
 sudo debconf-set-selections <<< "postfix postfix/main_mailer_type string 'Internet Site'"
 sudo debconf-set-selections <<< "postfix postfix/mailname string debexpo-dev"
 sudo apt-get update
-sudo apt-get install postfix python-lxml libapt-pkg-dev python-pip python-dev python-virtualenv python-django=1.7.1-1~bpo70+1 --yes
-sudo apt-get install --yes python-fedmsg -t wheezy-backports
+sudo apt-get install postfix python-lxml libapt-pkg-dev python-pip python-dev python-virtualenv python-django python-fedmsg python-apt --yes
 sudo apt-get build-dep --yes python-lxml
 echo '* discard:' | sudo sh -c 'cat > /etc/postfix/discard-transport'
 if ! grep -q transport_maps /etc/postfix/main.cf; then
@@ -31,7 +29,6 @@ if ! [ -f ~/debexpo/venv/bin/python ]; then
     virtualenv venv --system-site-packages
 fi
 . venv/bin/activate
-pip install https://launchpad.net/python-apt/main/0.7.8/+download/python-apt-0.8.5.tar.gz
 pip install --editable .
 paster setup-app development.ini
 python setup.py compile_catalog


### PR DESCRIPTION
It is more simple to install because backport packages are not needed.
