### PR TITLE
Add status page which shows each cron job status

### DIFF
--- a/debexpo/config/routing.py
+++ b/debexpo/config/routing.py
@@ -63,6 +63,7 @@ def make_map(config):
 
     map.connect('index', '/', controller='index', action='index')
     map.connect('contact', '/contact', controller='index', action='contact')
+    map.connect('status', '/status', controller='index', action='status')
     map.connect('intro-maintainers', '/intro-maintainers',
                 controller='index', action='intro_maintainers')
     map.connect('sponsors', '/sponsors', controller='sponsor', action='index')

--- a/debexpo/model/cronjob_info.py
+++ b/debexpo/model/cronjob_info.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+#   cronjob_info.py — cronjob_info table model
+#
+#   This file is part of debexpo - https://alioth.debian.org/projects/debexpo/
+#
+#   Copyright © 2016 Kentaro Hayshi <kenhys@gmail.com>
+#
+#   Permission is hereby granted, free of charge, to any person
+#   obtaining a copy of this software and associated documentation
+#   files (the "Software"), to deal in the Software without
+#   restriction, including without limitation the rights to use,
+#   copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the
+#   Software is furnished to do so, subject to the following
+#   conditions:
+#
+#   The above copyright notice and this permission notice shall be
+#   included in all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#   OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#   OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Holds cronjob_info table model.
+"""
+
+__author__ = 'Kentaro Hayashi'
+__copyright__ = 'Copyright © 2016 Kentaro Hayashi'
+__license__ = 'MIT'
+
+import json
+import os
+
+from mako.lookup import TemplateLookup
+from mako.exceptions import TopLevelLookupException
+
+from pylons import config
+
+import sqlalchemy as sa
+from sqlalchemy import orm
+
+import debexpo.lib
+
+from debexpo.model import meta, OrmObject
+
+t_cronjob_info = sa.Table('cronjob_info', meta.metadata,
+    sa.Column('id', sa.types.Integer, primary_key=True),
+    sa.Column('name', sa.types.Text(), nullable=False),
+    sa.Column('schedule', sa.types.Integer, nullable=False),
+    sa.Column('last_run', sa.types.DateTime, nullable=False),
+    )
+
+class CronJobInfo(OrmObject):
+    pass
+
+orm.mapper(CronJobInfo, t_cronjob_info)

--- a/debexpo/templates/base.mako
+++ b/debexpo/templates/base.mako
@@ -61,6 +61,10 @@
                         _('Contact'),
                         h.url('contact')) }
                 </li>
+		<li>${ h.tags.link_to(
+                        _('Status'),
+                        h.url('status')) }
+                </li>
             </ul>
         </div><!-- end navbar -->
         <p id="breadcrumbs">

--- a/debexpo/templates/index/status.mako
+++ b/debexpo/templates/index/status.mako
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+<%inherit file="/base.mako"/>
+
+<h1>${ _('Worker job status') }</h1>
+
+<table>
+    <tr>
+        <th>Job name</th>
+        <th>Last run</th>
+        <th>Interval</th>
+        <th>Status</th>
+    </tr>
+    % for job in c.jobs:
+    <tr class='qa'>
+        <td>${ job['name'] }</td>
+        <td>${ job['last_run'] }</td>
+        <td>${ job['interval'] }</td>
+        <td class='severity-${ job['status'] }'><span class='visibility'>${ job['message'] }</span></td>
+    </tr>
+    % endfor
+</table>
+
+<p>There are <span class='error-message'>${ c.pending_packages }</span> pending packages on queue.</p>


### PR DESCRIPTION
There is a situation that package upload is ok, but it is not listed on package list.
The mentors.debian.net user can't figure out what is wrong even though mentors.d.n worker is down.

This PR adds /status page for each cron job. and shows last run information on it.
We can find easily the reason of delay on mentors.d.n.
